### PR TITLE
fix #6: Error: Can't resolve 'input.scss'

### DIFF
--- a/src/lib/input/input.ts
+++ b/src/lib/input/input.ts
@@ -4,8 +4,8 @@ import { EmojiUtil } from '../util/util';
 
 @Component({
   selector: 'emoji-input',
-  templateUrl: 'input.html',
-  styleUrls: ['input.scss']
+  templateUrl: './input.html',
+  styleUrls: ['./input.scss']
 })
 export class EmojiInputComponent implements OnInit, OnChanges {
 


### PR DESCRIPTION
here is the fix.

I also tried to run the tests, but they seem to fail (disregarding if my changes are included or not):

```
ng test
Could not start watchman; falling back to NodeWatcher for file system events.
Visit http://ember-cli.com/user-guide/#watchman for more info.

WARNING in ./src/lib/input/input.ts
[14, 3]: Declaration of public instance member variable not allowed to appear after declaration of public instance member function
[6, 13]: The selector of the component "EmojiInputComponent" should have prefix "app" (https://goo.gl/cix8BY)

 @ ./src/lib/module.ts 9:2725-2749
 @ ./src/lib/index.ts
 @ ./src/app/app.component.spec.ts
 @ ./src \.spec\.ts
 @ ./src/test.ts

WARNING in ./~/@angular/core/src/linker/system_js_ng_module_factory_loader.js
45:15 Critical dependency: the request of a dependency is an expression

WARNING in ./~/@angular/core/src/linker/system_js_ng_module_factory_loader.js
57:15 Critical dependency: the request of a dependency is an expression

ERROR in [default] /Users/peter/repos/other/angular2-emoji/node_modules/@types/jasmine/index.d.ts:39:37 
A parameter initializer is only allowed in a function or constructor implementation.

ERROR in [default] /Users/peter/repos/other/angular2-emoji/node_modules/@types/jasmine/index.d.ts:39:45 
Cannot find name 'keyof'.

ERROR in [default] /Users/peter/repos/other/angular2-emoji/node_modules/@types/jasmine/index.d.ts:39:51 
'=' expected.
14 02 2017 10:53:38.292:WARN [karma]: No captured browser, open http://localhost:9876/
14 02 2017 10:53:38.299:INFO [karma]: Karma v1.2.0 server started at http://localhost:9876/
14 02 2017 10:53:38.299:INFO [launcher]: Launching browser Chrome with unlimited concurrency
14 02 2017 10:53:38.337:INFO [launcher]: Starting browser Chrome
14 02 2017 10:53:39.689:INFO [Chrome 56.0.2924 (Mac OS X 10.12.1)]: Connected on socket /#p7hRJlhk_R65IeJ5AAAA with id 27288284
Chrome 56.0.2924 (Mac OS X 10.12.1): Executed 0 of 0 ERROR (0.005 secs / 0 secs)
```